### PR TITLE
Fixed user input text is not updated when OnItemSetValue rerurns False.

### DIFF
--- a/Source/zObjInspector.pas
+++ b/Source/zObjInspector.pas
@@ -2594,15 +2594,15 @@ begin
   if Assigned(FOnItemSetValue) then
     Result := FOnItemSetValue(Self, PropItem, Value);
   if Result then
-    DefaultValueManager.SetValue(PropItem, Value);
-  if Result then
   begin
+    DefaultValueManager.SetValue(PropItem, Value);
+
     if PropItem.IsClass then
       { Must rebuild the list . }
       UpdateProperties();
-    FPropInspEdit.UpdateEditText;
-    Invalidate;
   end;
+  FPropInspEdit.UpdateEditText; // required on Result is True or False
+  Invalidate;
 end;
 
 procedure TzCustomObjInspector.ExpandAll;


### PR DESCRIPTION
Hi, again. I fixed a small issue.
When OnItemSetValue handler returns False,  user input text is not updated correctly.
