### PR TITLE
Floating number support

### DIFF
--- a/Packages/zControls_R.dpk
+++ b/Packages/zControls_R.dpk
@@ -43,6 +43,10 @@ contains
   zObjInspList in '..\Source\zObjInspList.pas',
   zRecList in '..\Source\zRecList.pas',
   zStringsDialog in '..\Source\zStringsDialog.pas' {StringsDialog},
-  zUtils in '..\Source\zUtils.pas';
+  zUtils in '..\Source\zUtils.pas',
+  FloatConv in '..\Source\FloatConv.pas',
+  FloatConv.Double in '..\Source\FloatConv.Double.pas',
+  FloatConv.Extended in '..\Source\FloatConv.Extended.pas',
+  FloatConv.Single in '..\Source\FloatConv.Single.pas';
 
 end.

--- a/Packages/zControls_R.dproj
+++ b/Packages/zControls_R.dproj
@@ -95,6 +95,11 @@
             <Form>StringsDialog</Form>
         </DCCReference>
         <DCCReference Include="..\Source\zUtils.pas"/>
+        <DCCReference Include="..\Source\FloatConv.pas"/>
+        <DCCReference Include="..\Source\FloatConv.Double.pas"/>
+        <DCCReference Include="..\Source\FloatConv.Extended.pas"/>
+        <DCCReference Include="..\Source\FloatConv.Single.pas"/>
+        <None Include="..\Source\FloatConv_impl.inc"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Source/FloatConv.Double.pas
+++ b/Source/FloatConv.Double.pas
@@ -1,0 +1,13 @@
+﻿unit FloatConv.Double;
+
+interface
+
+uses
+  FloatConv;
+
+type  
+  TFloat = Double;
+
+{$I FloatConv_impl.inc}
+
+end.

--- a/Source/FloatConv.Extended.pas
+++ b/Source/FloatConv.Extended.pas
@@ -1,0 +1,13 @@
+﻿unit FloatConv.Extended;
+
+interface
+
+uses
+  FloatConv;
+
+type  
+  TFloat = Extended;
+
+{$I FloatConv_impl.inc}
+
+end.

--- a/Source/FloatConv.Single.pas
+++ b/Source/FloatConv.Single.pas
@@ -1,0 +1,13 @@
+﻿unit FloatConv.Single;
+
+interface
+
+uses
+  FloatConv;
+
+type  
+  TFloat = Single;
+
+{$I FloatConv_impl.inc}
+
+end.

--- a/Source/FloatConv.pas
+++ b/Source/FloatConv.pas
@@ -1,0 +1,86 @@
+﻿unit FloatConv;
+
+interface
+
+type
+  TFloatFormatOption = (ffoConsiderSmallNumber, // show smaller number < 1e-Maxdigits
+                        ffoFixDigit);           // padding with 0
+  TFloatFormatOptions = set of TFloatFormatOption;
+
+
+function MyFormatFloat(Val: Single; MaxDigits, ExpPrecision: Integer;
+                       Options: TFloatFormatOptions = []): string; overload; //inline;
+
+function MyFormatFloat(Val: Double; MaxDigits, ExpPrecision: Integer;
+                       Options: TFloatFormatOptions = []): string; overload; //inline;
+
+function MyFormatFloat(Val: Extended; MaxDigits, ExpPrecision: Integer;
+                       Options: TFloatFormatOptions = []): string; overload; //inline;
+
+function MyStrToFloat(Str: string): Double; //inline;
+function MyStrToFloatS(Str: string): Single; //inline;
+function MyStrToFloatD(Str: string): Double; //inline;
+function MyStrToFloatE(Str: string): Extended; //inline;
+
+function MyTryStrToFloat(const S: string; out Value: Single): Boolean; overload;
+function MyTryStrToFloat(const S: string; out Value: Double): Boolean; overload;
+function MyTryStrToFloat(const S: string; out Value: Extended): Boolean; overload;
+
+implementation
+
+uses
+  FloatConv.Single,
+  FloatConv.Double,
+  FloatConv.Extended;
+
+function MyFormatFloat(Val: Single; MaxDigits, ExpPrecision: Integer; Options: TFloatFormatOptions = []): string;
+begin
+  Result := FloatConv.Single.MyFormatFloat(Val, MaxDigits, ExpPrecision, Options);
+end;
+
+function MyFormatFloat(Val: Double; MaxDigits, ExpPrecision: Integer; Options: TFloatFormatOptions = []): string;
+begin
+  Result := FloatConv.Double.MyFormatFloat(Val, MaxDigits, ExpPrecision, Options);
+end;
+
+function MyFormatFloat(Val: Extended; MaxDigits, ExpPrecision: Integer; Options: TFloatFormatOptions = []): string;
+begin
+  Result := FloatConv.Extended.MyFormatFloat(Val, MaxDigits, ExpPrecision, Options);
+end;
+
+function MyStrToFloat(Str: string): Double;
+begin
+  Result := FloatConv.Double.MyStrToFloat(Str);
+end;
+
+function MyStrToFloatS(Str: string): Single;
+begin
+  Result := FloatConv.Single.MyStrToFloat(Str);
+end;
+
+function MyStrToFloatD(Str: string): Double;
+begin
+  Result := FloatConv.Double.MyStrToFloat(Str);
+end;
+
+function MyStrToFloatE(Str: string): Extended;
+begin
+  Result := FloatConv.Extended.MyStrToFloat(Str);
+end;
+
+function MyTryStrToFloat(const S: string; out Value: Single): Boolean;
+begin
+  Result := FloatConv.Single.MyTryStrToFloat(S, Value);
+end;
+
+function MyTryStrToFloat(const S: string; out Value: Double): Boolean;
+begin
+  Result := FloatConv.Double.MyTryStrToFloat(S, Value);
+end;
+
+function MyTryStrToFloat(const S: string; out Value: Extended): Boolean;
+begin
+  Result := FloatConv.Extended.MyTryStrToFloat(S, Value);
+end;
+
+end.

--- a/Source/FloatConv_impl.inc
+++ b/Source/FloatConv_impl.inc
@@ -1,0 +1,134 @@
+﻿function MyStrToFloat(Str: string): TFloat; overload;
+
+function MyFormatFloat(Val: TFloat; MaxDigits, ExpPrecision: Integer;
+                       Options: TFloatFormatOptions = [ffoConsiderSmallNumber]): string; overload;
+
+function MyTryStrToFloat(const S: string; out Value: TFloat): Boolean;
+
+implementation
+
+uses
+  Math,
+  System.SysUtils,
+  System.RegularExpressions;
+
+function MyTryStrToFloat(const S: string; out Value: TFloat): Boolean;
+var
+  Str: string;
+  Sign: TFloat;
+const
+  cValidFloatRegExp = '^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$';
+begin
+  Str := S.Trim.ToLower;
+  Sign := 1.0;
+
+  if Str[1] = '-' then
+  begin
+    Sign := -1.0;
+    Str := Str.Remove(0,1);
+  end
+  else if Str[1] = '+' then
+    Str := Str.Remove(0,1);
+
+  if Str = 'nan' then
+    Value := NaN
+  else if Str = 'inf' then
+    Value := Infinity
+  else
+  begin
+    if not TryStrToFloat(Str, Value) then
+      // valid regexp => overflow
+      if TRegEx.IsMatch(Str, cValidFloatRegExp) then
+      begin
+        if Str.ToLower.Contains('e-') then
+          Value := 0
+        else
+          Value := Infinity;
+      end
+      else // invalid float
+      begin
+        Result := False;
+        Exit;
+      end;
+  end;
+  Value := Value * Sign;
+  Result := True;
+end;
+
+function MyStrToFloat(Str: string): TFloat;
+var
+  Sign: TFloat;
+const
+  cValidFloatRegExp = '^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$';
+begin
+  Str := Str.Trim.ToLower;
+  Sign := 1.0;
+
+  if Str[1] = '-' then
+  begin
+    Sign := -1.0;
+    Str := Str.Remove(0,1);
+  end
+  else if Str[1] = '+' then
+    Str := Str.Remove(0,1);
+
+  if Str = 'nan' then
+    Result := NaN
+  else if Str = 'inf' then
+    Result := Infinity
+  else
+  begin
+    if not TryStrToFloat(Str, Result) then
+      // valid regexp => overflow
+      if TRegEx.IsMatch(Str, cValidFloatRegExp) then
+      begin
+        if Str.ToLower.Contains('e-') then
+          Result := 0
+        else
+          Result := Infinity;
+      end
+      else // invalid float
+      begin
+        Result := StrToFloat(Str); // reraise Error
+      end;
+  end;
+
+  Result := Result * Sign;
+end;
+
+function MyFormatFloat(Val: TFloat; MaxDigits, ExpPrecision: Integer; Options: TFloatFormatOptions): string;
+var
+  Normal, Small, Big: string;
+  SArr: TArray<string>;
+  DigitChar: Char;
+begin
+  if ffoFixDigit in Options then
+    DigitChar := '0'
+  else
+    DigitChar := '#';
+
+  Normal := FormatFloat('0.'+StringOfChar(DigitChar,MaxDigits), Val).Replace('E','e');
+  if not (ffoFixDigit in Options) then
+    Normal := TRegEx.Replace(Normal,'\.0+$', ''); // 0.00 -> 0
+
+  if (ffoConsiderSmallNumber in Options) and
+     (not IsNan(Val) and (Abs(Val)>0) and (Abs(Val) < Power10(1.0, -MaxDigits)) and (Normal = '0')) then
+  begin
+    Small := FormatFloat('#.'+ StringOfChar(DigitChar,ExpPrecision-1)+'e+0', Val); // e+## doesn't works correctly
+    Result := Small;
+  end
+  else
+  begin
+    if Normal.Contains('e') then  // Big e
+    begin
+      SArr := Normal.Split(['e']);
+      Big := FormatFloat('0.'+StringOfChar('#',ExpPrecision-1), StrToFloat(SArr[0])) + 'e' + SArr[1];
+      Result := Big;
+    end
+    else
+      Result := Normal;
+  end;
+
+  // tweak output
+  Result := Result.Replace('NAN', 'NaN').Replace('INF', 'Inf');
+end;


### PR DESCRIPTION
This patch makes zInspector support floating number (Single, Double, Extended) property.

Supports FloatPreference property to control several format options below.
(I'm unfamiliar with mathematical term in English. It may be not accurate.)

!["FloatPreference property"](http://i.imgur.com/wGMfIIE.png "FloatPreference")
- MaxDigits - Maximum digit length under decimal point.
- ExpPrecision - precision parameter of n.mmmm*e^n format. (I'm afraid I forgot the detail of this, but perhaps, digit length of mmmm part)
- Format Options
  - ffoConsiderSmallNumber - Don't round small number and show precisely.
  - ffoFixDigit  - show number in fixed digit number (unless this option is set,  "0.00" is replaced to "0")