### PR TITLE
Fixed AV occurs on change component while editing some property

### DIFF
--- a/Source/zObjInspector.pas
+++ b/Source/zObjInspector.pas
@@ -3375,7 +3375,7 @@ begin
   UpdateEditControl;
 end;
 
-procedure TzCustomObjInspector.UpdateEditControl;
+procedure TzCustomObjInspector.UpdateEditControl(const SetValue: Boolean);
 var
   PItem: PPropItem;
   BtnWidth: Integer;
@@ -3383,7 +3383,10 @@ var
 begin
   if Assigned(FPropInspEdit) then
     if Assigned(FPropInspEdit.Parent) then
+    begin
+      FPropInspEdit.PropInfo := nil;
       FPropInspEdit.Visible := False;
+    end;
   if FSelectedIndex < 0 then
     Exit;
   UpdateSelIndex;
@@ -3721,7 +3724,8 @@ begin
   if not FPropItem.EqualTo(Value) then
   begin
     FPropItem := Value;
-    PropInfoChanged;
+    if Assigned(Value) then
+      PropInfoChanged;
   end;
 end;
 
@@ -3789,7 +3793,7 @@ end;
 procedure TzPropInspEdit.UpdateButton;
 begin
   FButton.Visible := False;
-  if (FInspector.FSelectedIndex < 0) or (FInspector.FSelectedIndex > FInspector.VisiblePropCount) then
+  if (not Assigned(FPropItem)) or (FInspector.FSelectedIndex < 0) or (FInspector.FSelectedIndex > FInspector.VisiblePropCount) then
     Exit;
   if not FPropItem^.Prop.IsWritable then
     Exit;


### PR DESCRIPTION
Hi, I added additional quick fix for [the AV problem you wrote](https://github.com/MahdiSafsafi/zcontrols/pull/12#issuecomment-300127663
) before.

I can confirm the problem with [madExcept](http://www.madshi.net/madExceptDescription.htm) with[ "instantly crash on buffer overrun" option](http://help.madshi.net/madExceptSettings1.htm).
(Without madExcept with this option, whether AV occurs or not depends on the contents of the current memory. That's why I can't reproduce the AV before.)

Without this patch, UpdateButton is called before SetPropItem is called.
(You can see FPropItem has invalid address below)
!["call stack"](http://i.imgur.com/PMcjoRK.png "call stack")

This patch may not be best solution to fix the problem, but It seems to work :-)