### PR TITLE
Make zObjInspector per Monitor DPI aware

### DIFF
--- a/Source/zObjInspector.pas
+++ b/Source/zObjInspector.pas
@@ -3107,7 +3107,7 @@ begin
   pmR := PlusMinBtnRect[Index];
   if PItem^.HasChild and (not FCircularLinkProps.Contains(PItem^.FQName)) then
   begin
-    DrawPlusMinus(Canvas, pmR.Left, pmR.Top, not PItem.Expanded, pmR.Width);
+    DrawPlusMinus(Canvas, pmR.Left, pmR.Top, not PItem.Expanded, pmR.Width, FCurrentPPI);
     HasPlusMinus := True;
   end;
   if not PItem^.IsCategory then

--- a/Source/zObjInspector.pas
+++ b/Source/zObjInspector.pas
@@ -784,7 +784,7 @@ type
 (*  Helper methods for TControl *)
 TControlHelper = class helper for TControl
 public
-  {$IF CompilerVersion < 33}   // older than Delphi Rio
+  {$IF CompilerVersion < 32}
   function FCurrentPPI: integer;
   {$IFEND}
   (* Scale a value according to the FCurrentPPI *)
@@ -793,7 +793,7 @@ public
   function PPIUnScale(Value: integer): integer;
 end;
 
-{$IF CompilerVersion < 33}   // older than Delphi Rio
+{$IF CompilerVersion < 32}
 function TControlHelper.FCurrentPPI: integer;
 begin
   Result := Screen.PixelsPerInch;
@@ -4239,7 +4239,7 @@ begin
       begin
         LDetails := StyleServices.GetElementDetails(tbCheckBoxUnCheckedNormal);
         StyleServices.GetElementSize(0, LDetails, esActual, Size);
-        Result := Size.Width;
+        Result := MulDiv(Size.Width, PPI, Screen.PixelsPerInch);
       end;
     vtColor: Result := MulDiv(ColorWidth + 1, PPI, 96);
   end;

--- a/Source/zUtils.pas
+++ b/Source/zUtils.pas
@@ -35,7 +35,7 @@ uses
   Vcl.Themes;
 
 function RectVCenter(var R: TRect; Bounds: TRect): TRect;
-procedure DrawPlusMinus(Canvas: TCanvas; X, Y: Integer; Collapsed: Boolean; Width: Integer = 9);
+procedure DrawPlusMinus(Canvas: TCanvas; X, Y: Integer; Collapsed: Boolean; Width: Integer = 9; PPI: Integer = 96);
 procedure zFillRect(DC: HDC; R: TRect; Color: COLORREF); overload;
 procedure zFillRect(DC: HDC; R: TRect; Color, BorderColor: COLORREF; DX, DY: Integer); overload;
 procedure DrawHorzDotLine(Canvas: TCanvas; X, Y, Width: Integer);
@@ -167,7 +167,7 @@ begin
   Result := R;
 end;
 
-procedure DrawPlusMinus(Canvas: TCanvas; X, Y: Integer; Collapsed: Boolean; Width: Integer = 9);
+procedure DrawPlusMinus(Canvas: TCanvas; X, Y: Integer; Collapsed: Boolean; Width: Integer = 9; PPI: Integer = 96);
 var
   Height: Integer;
   Details: TThemedElementDetails;
@@ -183,7 +183,8 @@ begin
       Details := LStyle.GetElementDetails(tcbCategoryGlyphClosed)
     else
       Details := LStyle.GetElementDetails(tcbCategoryGlyphOpened);
-    LStyle.DrawElement(Canvas.Handle, Details, Rect(X, Y, X + Width, Y + Width));
+    LStyle.DrawElement(Canvas.Handle, Details,
+      Rect(X, Y, X + Width, Y + Width){$IF CompilerVersion >= 33}, nil, PPI{$IFEND});
   end else begin
     Canvas.Pen.Color := clBtnShadow;
     Canvas.Brush.Color := clWindow;


### PR DESCRIPTION
With Delphi Rio and above, the changes provide support for per Monitor DPI awareness.  This means that when you move the zObjectInspector to a Window with different PPI or even when you display different zObjectInspectors to Monitors with different PPI the controls are displayed properly scaled.